### PR TITLE
Sql Source registration Bug Fix:

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: cohesity
 name: dataprotect
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.3
+version: 1.0.4
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/module_utils/cohesity_auth.py
+++ b/plugins/module_utils/cohesity_auth.py
@@ -13,7 +13,7 @@ DOCUMENTATION = """
 module_utils: cohesity_auth
 short_description: The **CohesityAuth** utils module provides the authentication token manage
 for Cohesity Platforms.
-version_added: 1.0.3
+version_added: 1.0.4
 description:
     - The **CohesityAuth** utils module provides the authentication token manage
 for Cohesity Platforms.

--- a/plugins/module_utils/cohesity_hints.py
+++ b/plugins/module_utils/cohesity_hints.py
@@ -14,7 +14,7 @@ DOCUMENTATION = """
 module_utils: cohesity_hints
 short_description: The **CohesityHints** utils module provides standard methods for returning query data
 from Cohesity Platforms.
-version_added: 1.0.3
+version_added: 1.0.4
 description:
     - The **CohesityHints** utils module provides standard methods for returning query data
 from Cohesity Platforms.
@@ -592,7 +592,7 @@ def unregister_source(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
 
         response = open_url(
@@ -658,7 +658,7 @@ def check__protection_group__exists(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + self["token"],
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         response = open_url(
             url=uri,

--- a/plugins/module_utils/cohesity_utilities.py
+++ b/plugins/module_utils/cohesity_utilities.py
@@ -13,7 +13,7 @@ DOCUMENTATION = """
 module_utils: cohesity_utilities
 short_description: The **CohesityUtilities** utils module provides the authentication token manage
 for Cohesity Platforms.
-version_added: 1.0.3
+version_added: 1.0.4
 description:
     - The **CohesityUtilities** utils module provides the authentication token manage
 for Cohesity Platforms.

--- a/plugins/modules/cohesity_agent.py
+++ b/plugins/modules/cohesity_agent.py
@@ -118,7 +118,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Management of Cohesity Physical Agent"
-version_added: 1.0.3
+version_added: 1.0.4
 """
 
 import os
@@ -334,13 +334,13 @@ def download_agent(module, path):
             headers = {
                 "Accept": "application/octet-stream",
                 "Authorization": "Bearer " + token,
-                "user-agent": "cohesity-ansible/v1.0.3",
+                "user-agent": "cohesity-ansible/v1.0.4",
             }
         else:
             uri = module.params.get("download_uri")
             headers = {
                 "Accept": "application/octet-stream",
-                "user-agent": "cohesity-ansible/v1.0.3",
+                "user-agent": "cohesity-ansible/v1.0.4",
             }
 
         agent = open_url(
@@ -615,7 +615,7 @@ def get_source_details(module, source_id):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         response = open_url(
             url=uri,
@@ -667,7 +667,7 @@ def update_agent(module):
             headers = {
                 "Accept": "application/json",
                 "Authorization": "Bearer " + token,
-                "user-agent": "cohesity-ansible/v1.0.3",
+                "user-agent": "cohesity-ansible/v1.0.4",
             }
             payload = {"agentIds": [source_details["agent"]["id"]]}
             open_url(

--- a/plugins/modules/cohesity_clone_vm.py
+++ b/plugins/modules/cohesity_clone_vm.py
@@ -119,7 +119,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Management of Cohesity VM Clone"
-version_added: 1.0.3
+version_added: 1.0.4
 """
 
 
@@ -485,7 +485,7 @@ def main():
 
     global cohesity_client
     base_controller = BaseController()
-    base_controller.global_headers["user-agent"] = "cohesity-ansible/v1.0.3"
+    base_controller.global_headers["user-agent"] = "cohesity-ansible/v1.0.4"
     cohesity_client = get_cohesity_client(module)
     clone_exists, clone_details = get_clone_task(module, False)
 

--- a/plugins/modules/cohesity_facts.py
+++ b/plugins/modules/cohesity_facts.py
@@ -15,7 +15,7 @@ module: cohesity_facts
 short_description: Gather facts about a Cohesity Cluster.
 description:
     - Gather facts about Cohesity Clusters.
-version_added: 1.0.3
+version_added: 1.0.4
 author: "Naveena (@naveena-maplelabs)"
 options:
   cluster:

--- a/plugins/modules/cohesity_job.py
+++ b/plugins/modules/cohesity_job.py
@@ -198,7 +198,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Management of Cohesity Protection Jobs"
-version_added: 1.0.3
+version_added: 1.0.4
 """
 EXAMPLES = """
 # Create a new Physical Server Protection Job
@@ -516,7 +516,7 @@ def get_vmware_ids(module, job_meta_data, job_details, vm_names):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         response = open_url(
             url=uri,
@@ -554,7 +554,7 @@ def get_vmware_vm_ids(module, job_meta_data, job_details, vm_names):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         response = open_url(
             url=uri,
@@ -599,7 +599,7 @@ def get_view_storage_domain_id(module, self):
         headers = {
             "Accept": "application/json",
             "DOCUMENT": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         response = open_url(
             url=uri,
@@ -664,7 +664,7 @@ def register_job(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         payload = self.copy()
 
@@ -752,7 +752,7 @@ def start_job(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         source_ids = payload.get("sourceIds", [])
         payload = dict()
@@ -811,7 +811,7 @@ def update_job(module, job_details, update_source_ids=None):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         payload = job_details.copy()
         del payload["token"]
@@ -873,7 +873,7 @@ def get_prot_job_details(self, module):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         response = open_url(
             url=uri,
@@ -927,7 +927,7 @@ def stop_job(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         payload = self.copy()
 
@@ -990,7 +990,7 @@ def unregister_job(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
 
         payload = dict(deleteSnapshots=self["deleteSnapshots"])

--- a/plugins/modules/cohesity_oracle_job.py
+++ b/plugins/modules/cohesity_oracle_job.py
@@ -131,7 +131,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Management of Cohesity Protection Jobs"
-version_added: 1.0.3
+version_added: 1.0.4
 """
 
 EXAMPLES = """

--- a/plugins/modules/cohesity_oracle_restore.py
+++ b/plugins/modules/cohesity_oracle_restore.py
@@ -135,7 +135,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Restore one or more Virtual Machines from Cohesity Protection Jobs"
-version_added: 1.0.3
+version_added: 1.0.4
 """
 
 EXAMPLES = """

--- a/plugins/modules/cohesity_oracle_source.py
+++ b/plugins/modules/cohesity_oracle_source.py
@@ -76,7 +76,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Management of Cohesity Protection Sources"
-version_added: 1.0.3
+version_added: 1.0.4
 """
 
 

--- a/plugins/modules/cohesity_plugin.py
+++ b/plugins/modules/cohesity_plugin.py
@@ -92,7 +92,7 @@ options:
       - "Determines whether to upgrade the connector plugin if already installed."
     type: bool
 short_description: "Management of Cohesity Datastore Plugin"
-version_added: "1.0.3"
+version_added: "1.0.4"
 """
 
 EXAMPLES = """
@@ -202,7 +202,7 @@ def download_datastore_plugin(module):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-plugin": "cohesity-ansible/v1.0.3",
+            "user-plugin": "cohesity-ansible/v1.0.4",
         }
         response = open_url(
             url=uri,
@@ -249,7 +249,7 @@ def update_global_allow_lists(module):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-plugin": "cohesity-ansible/v1.0.3",
+            "user-plugin": "cohesity-ansible/v1.0.4",
         }
         response = open_url(
             url=uri,

--- a/plugins/modules/cohesity_policy.py
+++ b/plugins/modules/cohesity_policy.py
@@ -99,7 +99,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Cohesity Protection Policy"
-version_added: 1.0.3
+version_added: 1.0.4
 """
 
 EXAMPLES = """
@@ -439,7 +439,7 @@ def main():
 
     global cohesity_client
     base_controller = BaseController()
-    base_controller.global_headers["user-agent"] = "cohesity-ansible/v1.0.3"
+    base_controller.global_headers["user-agent"] = "cohesity-ansible/v1.0.4"
     cohesity_client = get_cohesity_client(module)
     policy_exists, policy_details = get_policy_details(module)
 

--- a/plugins/modules/cohesity_restore_file.py
+++ b/plugins/modules/cohesity_restore_file.py
@@ -15,7 +15,7 @@ description:
     - Ansible Module used to start a Cohesity Recovery Job on a Cohesity Cluster.
     - When executed in a playbook, the Cohesity Recovery Job will be validated and the appropriate state action
     - will be applied.
-version_added: 1.0.3
+version_added: 1.0.4
 author: "Naveena (@naveena-maplelabs)"
 options:
   cluster:
@@ -380,7 +380,7 @@ def start_restore(module, uri, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         payload = self.copy()
 
@@ -429,7 +429,7 @@ def wait_restore_complete(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         attempts = 0
         # => Wait for the restore based on a predetermined number of minutes with checks every 30 seconds.

--- a/plugins/modules/cohesity_restore_vm.py
+++ b/plugins/modules/cohesity_restore_vm.py
@@ -180,7 +180,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Restore one or more Virtual Machines from Cohesity Protection Jobs"
-version_added: 1.0.3
+version_added: 1.0.4
 """
 
 EXAMPLES = """

--- a/plugins/modules/cohesity_restore_vmware_file.py
+++ b/plugins/modules/cohesity_restore_vmware_file.py
@@ -14,7 +14,7 @@ description:
     - Ansible Module used to start a Cohesity Recovery Job on a Cohesity Cluster.
     - When executed in a playbook, the Cohesity Recovery Job will be validated and the appropriate state action
     - will be applied.
-version_added: 1.0.3
+version_added: 1.0.4
 author: "Naveena (@naveena-maplelabs)"
 
 options:
@@ -265,7 +265,7 @@ def start_restore(module, uri, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         payload = self.copy()
 
@@ -353,7 +353,7 @@ def wait_restore_complete(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         attempts = 0
         # => Wait for the restore based on a predetermined number of minutes with checks every 30 seconds.

--- a/plugins/modules/cohesity_uda_protection_group.py
+++ b/plugins/modules/cohesity_uda_protection_group.py
@@ -166,7 +166,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Management of Cohesity UDA Protection Groups"
-version_added: 1.0.3
+version_added: 1.0.4
 """
 
 EXAMPLES = """
@@ -415,7 +415,7 @@ def create_group(module, self, body):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         response = open_url(
             url=uri,

--- a/plugins/modules/cohesity_uda_source.py
+++ b/plugins/modules/cohesity_uda_source.py
@@ -111,7 +111,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Management of UDA Protection Sources"
-version_added: 1.0.3
+version_added: 1.0.4
 """
 
 EXAMPLES = """
@@ -197,7 +197,7 @@ def register_source(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.0.3",
+            "user-agent": "cohesity-ansible/v1.0.4",
         }
         payload = dict(
             environment="kUDA",

--- a/plugins/modules/cohesity_view.py
+++ b/plugins/modules/cohesity_view.py
@@ -14,7 +14,7 @@ module: cohesity_view
 short_description: Management of Cohesity View
 description:
     - Ansible Module to create View.
-version_added: 1.0.3
+version_added: 1.0.4
 author: "Naveena (@naveena-maplelabs)"
 options:
   case_insensitive:
@@ -458,7 +458,7 @@ def main():
 
     global cohesity_client
     base_controller = BaseController()
-    base_controller.global_headers["user-agent"] = "cohesity-ansible/v1.0.3"
+    base_controller.global_headers["user-agent"] = "cohesity-ansible/v1.0.4"
     cohesity_client = get_cohesity_client(module)
     view_exists, view_details = get_view_details(module)
 

--- a/plugins/modules/cohesity_win_agent.py
+++ b/plugins/modules/cohesity_win_agent.py
@@ -17,7 +17,7 @@ description:
     - When executed in a playbook, the Cohesity Agent installation will be validated and the appropriate
     - state action will be applied.  The most recent version of the Cohesity Agent will be automatically
     - downloaded to the host.
-version_added: 1.0.3
+version_added: 1.0.4
 author: "Naveena (@naveena-maplelabs)"
 options:
   cluster:


### PR DESCRIPTION
Issue:
- Error while parsing request body: json: cannot unmarshal bool into Go
  struct field RegisterApplicationServersParameters.protectionSourceId of type int64

Fix:

- Added a new field to store the physical source id, which can be used for
  sql source registration.

Tests Done:
- Register a source as physical and then as sql source.
- Register an existing source as sql source.