### PR TITLE
Oracle Job Creation Bug

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: cohesity
 name: dataprotect
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.1.3
+version: 1.1.4
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/module_utils/cohesity_auth.py
+++ b/plugins/module_utils/cohesity_auth.py
@@ -13,7 +13,7 @@ DOCUMENTATION = """
 module_utils: cohesity_auth
 short_description: The **CohesityAuth** utils module provides the authentication token manage
 for Cohesity Platforms.
-version_added: 1.1.3
+version_added: 1.1.4
 description:
     - The **CohesityAuth** utils module provides the authentication token manage
 for Cohesity Platforms.

--- a/plugins/module_utils/cohesity_hints.py
+++ b/plugins/module_utils/cohesity_hints.py
@@ -14,7 +14,7 @@ DOCUMENTATION = """
 module_utils: cohesity_hints
 short_description: The **CohesityHints** utils module provides standard methods for returning query data
 from Cohesity Platforms.
-version_added: 1.1.3
+version_added: 1.1.4
 description:
     - The **CohesityHints** utils module provides standard methods for returning query data
 from Cohesity Platforms.
@@ -627,7 +627,7 @@ def unregister_source(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
 
         response = open_url(
@@ -701,7 +701,7 @@ def check__protection_group__exists(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + self["token"],
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,
@@ -760,7 +760,7 @@ def get_resource_pool_id(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,

--- a/plugins/module_utils/cohesity_utilities.py
+++ b/plugins/module_utils/cohesity_utilities.py
@@ -13,7 +13,7 @@ DOCUMENTATION = """
 module_utils: cohesity_utilities
 short_description: The **CohesityUtilities** utils module provides the authentication token manage
 for Cohesity Platforms.
-version_added: 1.1.3
+version_added: 1.1.4
 description:
     - The **CohesityUtilities** utils module provides the authentication token manage
 for Cohesity Platforms.

--- a/plugins/modules/cohesity_agent.py
+++ b/plugins/modules/cohesity_agent.py
@@ -334,13 +334,13 @@ def download_agent(module, path):
             headers = {
                 "Accept": "application/octet-stream",
                 "Authorization": "Bearer " + token,
-                "user-agent": "cohesity-ansible/v1.1.3",
+                "user-agent": "cohesity-ansible/v1.1.4",
             }
         else:
             uri = module.params.get("download_uri")
             headers = {
                 "Accept": "application/octet-stream",
-                "user-agent": "cohesity-ansible/v1.1.3",
+                "user-agent": "cohesity-ansible/v1.1.4",
             }
 
         agent = open_url(
@@ -612,7 +612,7 @@ def get_source_details(module, source_id):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,
@@ -664,7 +664,7 @@ def update_agent(module):
             headers = {
                 "Accept": "application/json",
                 "Authorization": "Bearer " + token,
-                "user-agent": "cohesity-ansible/v1.1.3",
+                "user-agent": "cohesity-ansible/v1.1.4",
             }
             payload = {"agentIds": [source_details["agent"]["id"]]}
             open_url(

--- a/plugins/modules/cohesity_cancel_migration.py
+++ b/plugins/modules/cohesity_cancel_migration.py
@@ -64,7 +64,7 @@ options:
 extends_documentation_fragment:
   - cohesity.dataprotect.cohesity
 short_description: Cancel the VM migration
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 EXAMPLES = """
@@ -129,7 +129,7 @@ def check__protection_restore__exists(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,
@@ -176,7 +176,7 @@ def cancel_migration(module, task_id):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,

--- a/plugins/modules/cohesity_clone_vm.py
+++ b/plugins/modules/cohesity_clone_vm.py
@@ -127,7 +127,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Management of Cohesity VM Clone"
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 
@@ -506,7 +506,7 @@ def main():
 
     global cohesity_client
     base_controller = BaseController()
-    base_controller.global_headers["user-agent"] = "cohesity-ansible/v1.1.3"
+    base_controller.global_headers["user-agent"] = "cohesity-ansible/v1.1.4"
     cohesity_client = get_cohesity_client(module)
     clone_exists, clone_details = get_clone_task(module, False)
 

--- a/plugins/modules/cohesity_facts.py
+++ b/plugins/modules/cohesity_facts.py
@@ -15,7 +15,7 @@ module: cohesity_facts
 short_description: Gather facts about a Cohesity Cluster.
 description:
     - Gather facts about Cohesity Clusters.
-version_added: 1.1.3
+version_added: 1.1.4
 author: "Naveena (@naveena-maplelabs)"
 options:
   cluster:

--- a/plugins/modules/cohesity_finalize_migration.py
+++ b/plugins/modules/cohesity_finalize_migration.py
@@ -65,7 +65,7 @@ options:
 extends_documentation_fragment:
   - cohesity.dataprotect.cohesity
 short_description: Finalize the VM migration
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 EXAMPLES = """
@@ -154,7 +154,7 @@ def finalize_migration(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         body = {
             "restoreTaskId": self["task_id"],

--- a/plugins/modules/cohesity_job.py
+++ b/plugins/modules/cohesity_job.py
@@ -227,7 +227,7 @@ options:
 extends_documentation_fragment:
   - cohesity.dataprotect.cohesity
 short_description: Management of Cohesity Protection Jobs
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 EXAMPLES = """
@@ -586,7 +586,7 @@ def get_vmware_ids(module, job_meta_data, job_details, vm_names):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,
@@ -626,7 +626,7 @@ def get_view_storage_domain_id(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,
@@ -691,7 +691,7 @@ def register_job(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         payload = self.copy()
 
@@ -796,7 +796,7 @@ def start_job(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         source_ids = payload.get("sourceIds", [])
         payload = dict()
@@ -855,7 +855,7 @@ def update_job(module, job_details, update_source_ids=None):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         payload = job_details.copy()
         del payload["token"]
@@ -917,7 +917,7 @@ def get_prot_job_details(self, module):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,
@@ -978,7 +978,7 @@ def stop_job(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         payload = self.copy()
 
@@ -1042,7 +1042,7 @@ def unregister_job(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
 
         payload = dict(deleteSnapshots=self["deleteSnapshots"])

--- a/plugins/modules/cohesity_migrate_vm.py
+++ b/plugins/modules/cohesity_migrate_vm.py
@@ -165,7 +165,7 @@ options:
 extends_documentation_fragment:
   - cohesity.dataprotect.cohesity
 short_description: Migrate one or more Virtual Machines from Cohesity Migrate Jobs
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 EXAMPLES = """
@@ -279,7 +279,7 @@ def get_source_details(module):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,
@@ -327,7 +327,7 @@ def get_backup_job_run_id(module, job_id):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,
@@ -367,7 +367,7 @@ def get_backup_job_ids(module, job_names):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,
@@ -411,7 +411,7 @@ def get_vmware_source_objects(module, source_id):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
 
         response = open_url(
@@ -473,7 +473,7 @@ def start_restore(module, uri, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         payload = self.copy()
 
@@ -515,7 +515,7 @@ def create_migration_task(module, body):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         # module.fail_json(msg=body)
         response = open_url(
@@ -605,7 +605,7 @@ def get_protection_groups(module):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,

--- a/plugins/modules/cohesity_migration_status.py
+++ b/plugins/modules/cohesity_migration_status.py
@@ -61,7 +61,7 @@ options:
 extends_documentation_fragment:
   - cohesity.dataprotect.cohesity
 short_description: Check Sync status of objects available in the VM migration task
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 EXAMPLES = """
@@ -148,7 +148,7 @@ def get_migration_status(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,
@@ -180,7 +180,7 @@ def get_task_status(module, task_id):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,

--- a/plugins/modules/cohesity_oracle_job.py
+++ b/plugins/modules/cohesity_oracle_job.py
@@ -131,7 +131,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Management of Cohesity Protection Jobs"
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 EXAMPLES = """
@@ -183,12 +183,12 @@ try:
     # => When unit testing, we need to look in the correct location however, when run via ansible,
     # => the expectation is that the modules will live under ansible.
     from ansible.module_utils.urls import urllib_error
+    from ansible_collections.cohesity.dataprotect.plugins.module_utils.cohesity_hints import (
+        get_cohesity_client,
+    )
     from ansible_collections.cohesity.dataprotect.plugins.module_utils.cohesity_utilities import (
         cohesity_common_argument_spec,
         raise__cohesity_exception__handler,
-    )
-    from ansible_collections.cohesity.dataprotect.plugins.module_utils.cohesity_hints import (
-        get_cohesity_client,
     )
 except Exception:
     pass
@@ -527,7 +527,7 @@ def main():
         check__mandatory__params(module)
         body = ProtectionJobRequestBody()
         body.name = module.params.get("name")
-        body.parent_source_id = source_id
+        body.parent_source_id = parent_id
         body.source_ids = [source_id]
         body.view_box_id = get__storage_domain_id__by_name(module)
         body.environment = module.params.get("environment")
@@ -603,6 +603,7 @@ def main():
                 minute=int(start_time[2] + start_time[3]),
             )
         try:
+            body.qos_type = "kBackupAll"
             if job_exists:
                 response = cohesity_client.protection_jobs.update_protection_job(
                     body, job_exists

--- a/plugins/modules/cohesity_oracle_restore.py
+++ b/plugins/modules/cohesity_oracle_restore.py
@@ -135,7 +135,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Restore one or more Virtual Machines from Cohesity Protection Jobs"
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 EXAMPLES = """

--- a/plugins/modules/cohesity_oracle_source.py
+++ b/plugins/modules/cohesity_oracle_source.py
@@ -82,7 +82,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Management of Cohesity Protection Sources"
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 

--- a/plugins/modules/cohesity_plugin.py
+++ b/plugins/modules/cohesity_plugin.py
@@ -92,7 +92,7 @@ options:
       - "Determines whether to upgrade the connector plugin if already installed."
     type: bool
 short_description: "Management of Cohesity Datastore Plugin"
-version_added: "1.1.3"
+version_added: "1.1.4"
 """
 
 EXAMPLES = """
@@ -205,7 +205,7 @@ def download_datastore_plugin(module):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-plugin": "cohesity-ansible/v1.1.3",
+            "user-plugin": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,
@@ -252,7 +252,7 @@ def update_global_allow_lists(module):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-plugin": "cohesity-ansible/v1.1.3",
+            "user-plugin": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,

--- a/plugins/modules/cohesity_policy.py
+++ b/plugins/modules/cohesity_policy.py
@@ -103,7 +103,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Cohesity Protection Policy"
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 EXAMPLES = """
@@ -506,7 +506,7 @@ def main():
 
     global cohesity_client
     base_controller = BaseController()
-    base_controller.global_headers["user-agent"] = "cohesity-ansible/v1.1.3"
+    base_controller.global_headers["user-agent"] = "cohesity-ansible/v1.1.4"
     cohesity_client = get_cohesity_client(module)
     policy_exists, policy_details = get_policy_details(module)
 

--- a/plugins/modules/cohesity_restore_file.py
+++ b/plugins/modules/cohesity_restore_file.py
@@ -15,7 +15,7 @@ description:
     - Ansible Module used to start a Cohesity Recovery Job on a Cohesity Cluster.
     - When executed in a playbook, the Cohesity Recovery Job will be validated and the appropriate state action
     - will be applied.
-version_added: 1.1.3
+version_added: 1.1.4
 author: "Naveena (@naveena-maplelabs)"
 options:
   cluster:
@@ -379,7 +379,7 @@ def start_restore(module, uri, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         payload = self.copy()
 
@@ -428,7 +428,7 @@ def wait_restore_complete(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         attempts = 0
         # => Wait for the restore based on a predetermined number of minutes with checks every 30 seconds.

--- a/plugins/modules/cohesity_restore_vm.py
+++ b/plugins/modules/cohesity_restore_vm.py
@@ -190,7 +190,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Restore one or more Virtual Machines from Cohesity Protection Jobs"
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 EXAMPLES = """
@@ -305,7 +305,7 @@ def get_source_details(module, restore_to_source):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         response = open_url(
             url=uri,
@@ -354,7 +354,7 @@ def get_vmware_source_objects(module, source_id):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
 
         response = open_url(
@@ -432,7 +432,7 @@ def get__vmware_snapshot_information__by_source(module, self, source_details):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         objects = open_url(
             url=uri,
@@ -580,7 +580,7 @@ def start_restore(module, uri, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         payload = self.copy()
 
@@ -629,7 +629,7 @@ def wait_restore_complete(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         attempts = 0
         # => Wait for the restore based on a predetermined number of minutes with checks every 30 seconds.

--- a/plugins/modules/cohesity_restore_vmware_file.py
+++ b/plugins/modules/cohesity_restore_vmware_file.py
@@ -14,7 +14,7 @@ description:
     - Ansible Module used to start a Cohesity Recovery Job on a Cohesity Cluster.
     - When executed in a playbook, the Cohesity Recovery Job will be validated and the appropriate state action
     - will be applied.
-version_added: 1.1.3
+version_added: 1.1.4
 author: "Naveena (@naveena-maplelabs)"
 
 options:
@@ -265,7 +265,7 @@ def start_restore(module, uri, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         payload = self.copy()
 
@@ -353,7 +353,7 @@ def wait_restore_complete(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         attempts = 0
         # => Wait for the restore based on a predetermined number of minutes with checks every 30 seconds.
@@ -452,7 +452,7 @@ def main():
 
     global cohesity_client
     base_controller = BaseController()
-    base_controller.global_headers["user-agent"] = "Ansible-v1.1.3"
+    base_controller.global_headers["user-agent"] = "Ansible-v1.1.4"
     cohesity_client = get_cohesity_client(module)
 
     if module.params.get("backup_id"):

--- a/plugins/modules/cohesity_source.py
+++ b/plugins/modules/cohesity_source.py
@@ -187,7 +187,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Management of Cohesity Protection Sources"
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 EXAMPLES = """
@@ -375,7 +375,7 @@ def refresh_source(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         uri = (
             "https://"
@@ -420,7 +420,7 @@ def register_sql_source(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         sql_payload = dict(
             applications=["kSQL"],
@@ -468,7 +468,7 @@ def register_source(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         payload = self.copy()
         payload["environment"] = "k" + self["environment"]

--- a/plugins/modules/cohesity_sync_objects.py
+++ b/plugins/modules/cohesity_sync_objects.py
@@ -66,7 +66,7 @@ options:
 extends_documentation_fragment:
   - cohesity.dataprotect.cohesity
 short_description: Sync objects available in the VM migration task
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 EXAMPLES = """
@@ -154,7 +154,7 @@ def sync_objects(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         body = {
             "restoreTaskId": self["task_id"],

--- a/plugins/modules/cohesity_uda_protection_group.py
+++ b/plugins/modules/cohesity_uda_protection_group.py
@@ -199,7 +199,7 @@ options:
 extends_documentation_fragment:
   - cohesity.dataprotect.cohesity
 short_description: Management of Cohesity UDA Protection Groups
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 EXAMPLES = """

--- a/plugins/modules/cohesity_uda_source.py
+++ b/plugins/modules/cohesity_uda_source.py
@@ -128,7 +128,7 @@ options:
 extends_documentation_fragment:
 - cohesity.dataprotect.cohesity
 short_description: "Management of UDA Protection Sources"
-version_added: 1.1.3
+version_added: 1.1.4
 """
 
 EXAMPLES = """
@@ -218,7 +218,7 @@ def register_source(module, self):
         headers = {
             "Accept": "application/json",
             "Authorization": "Bearer " + token,
-            "user-agent": "cohesity-ansible/v1.1.3",
+            "user-agent": "cohesity-ansible/v1.1.4",
         }
         payload = dict(
             environment="kUDA",

--- a/plugins/modules/cohesity_view.py
+++ b/plugins/modules/cohesity_view.py
@@ -14,7 +14,7 @@ module: cohesity_view
 short_description: Management of Cohesity View
 description:
     - Ansible Module to create View.
-version_added: 1.1.3
+version_added: 1.1.4
 author: "Naveena (@naveena-maplelabs)"
 options:
   case_insensitive:
@@ -460,7 +460,7 @@ def main():
 
     global cohesity_client
     base_controller = BaseController()
-    base_controller.global_headers["user-agent"] = "cohesity-ansible/v1.1.3"
+    base_controller.global_headers["user-agent"] = "cohesity-ansible/v1.1.4"
     cohesity_client = get_cohesity_client(module)
     view_exists, view_details = get_view_details(module)
 

--- a/plugins/modules/cohesity_win_agent.py
+++ b/plugins/modules/cohesity_win_agent.py
@@ -17,7 +17,7 @@ description:
     - When executed in a playbook, the Cohesity Agent installation will be validated and the appropriate
     - state action will be applied.  The most recent version of the Cohesity Agent will be automatically
     - downloaded to the host.
-version_added: 1.1.3
+version_added: 1.1.4
 author: "Naveena (@naveena-maplelabs)"
 options:
   cluster:


### PR DESCRIPTION
1) Oracle job is created but the objects are not available and the protection job run fails.
2) Though objects were selected, 0 objects were listed under job settings.

Fix:
1) Parent Source Id and the source Id provided were same and not the oracle parent Id, updating the code with actual parent Id fixed the issue.

Test:
1) Created an oracle job and the job run now works as expected and the object count listed uner settings tab is correct.