### PR TITLE
Bug Fix: SMB Source registration failure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ collections:
 - python version >= '3.6'
 - cohesity_management_sdk >= 1.6.0
 
+To install the requirements, run **pip install -r [requirement.txt](https://github.com/cohesity/ansible-collection/blob/main/requirements.txt)**
+
 ## Table of contents
 
  - [Getting Started](https://github.com/cohesity/ansible-collection/blob/main/README.md#get-started)

--- a/docs/modules/cohesity_source.rst
+++ b/docs/modules/cohesity_source.rst
@@ -225,7 +225,7 @@ Examples
         endpoint: \\myfileserver.host.lab\data
         environment: GenericNas
         nas_protocol: SMB
-        nas_username: administrator
+        nas_username: DOMAIN/administrator or administrator@DOMAIN
         nas_password: password
         state: present
 

--- a/docs/modules/cohesity_storage_domain.rst
+++ b/docs/modules/cohesity_storage_domain.rst
@@ -48,7 +48,7 @@ Parameters
     Password belonging to the selected Username. This parameter will not be logged.
 
 
-  ad_domain_name (True, str, None)
+  ad_domain_name (False, str, None)
     Specifies an active directory domain that this storage domain box is mapped to.
 
 
@@ -56,7 +56,7 @@ Parameters
     Specifies the Cluster Partition id where the Storage Domain is located.
 
 
-  cluster_partition_name (optional, str, DefaultPartition)
+  cluster_partition_name (optional, str, None)
     Specifies the Cluster Partition Name where the Storage Domain is located.
 
 

--- a/playbooks/nas-workflow/create_nas_workflow.yml
+++ b/playbooks/nas-workflow/create_nas_workflow.yml
@@ -1,0 +1,24 @@
+# => Create/Update a Generic Nas protection job for list of Sources.
+---
+- hosts: workstation
+  gather_facts: false
+  collections:
+    - cohesity.dataprotect
+  tasks:
+    - name: Create/Update a Generic Nas Protection job.
+      cohesity_job:
+        cluster: "{{ cohesity_server }}"
+        username: "{{ cohesity_username }}"
+        password: "{{ cohesity_password }}"
+        validate_certs: "{{ cohesity_validate_certs }}"
+        state: "present"
+        name: "SqlJob"
+        environment: "GenericNas"
+        sources:
+          - endpoint: "x.x.x.x:/Test"
+          - endpoint: "x.x.x.x:/Test1"
+          - endpoint: "\\\\x.x.x.x\\Test"
+        protection_policy: "Bronze"
+        storage_domain: "DefaultStorageDomain"
+        time_zone: "America/Los_Angeles"
+        start_time: "00:00"

--- a/playbooks/nas-workflow/register_NAS_SMB_source.yml
+++ b/playbooks/nas-workflow/register_NAS_SMB_source.yml
@@ -15,7 +15,7 @@
         endpoint: "SMB-Endpoint"
         environment: "GenericNas"
         nas_protocol: "SMB"
-        nas_username: "admin"
+        nas_username: "admin@LOCAL"
         nas_password: "admin"
         skip_validation: "true"
         nas_type: "Host"

--- a/playbooks/nas-workflow/remove_source_from_job.yml
+++ b/playbooks/nas-workflow/remove_source_from_job.yml
@@ -1,0 +1,21 @@
+# => Remove one or more sources from Generic Nas protection job.
+---
+- hosts: workstation
+  gather_facts: false
+  collections:
+    - cohesity.dataprotect
+  tasks:
+    - name: Removing source(s) from a Generic Nas Protection job.
+      cohesity_job:
+        cluster: "{{ cohesity_server }}"
+        username: "{{ cohesity_username }}"
+        password: "{{ cohesity_password }}"
+        validate_certs: "{{ cohesity_validate_certs }}"
+        state: "present"
+        name: "SqlJob"
+        environment: "GenericNas"
+        sources:
+        # These two sources will be removed from job SqlJob.
+          - endpoint: "\\\\x.x.x.x\\Test"
+          - endpoint: "x.x.x.x:/Test"
+        delete_sources: true

--- a/plugins/modules/cohesity_job.py
+++ b/plugins/modules/cohesity_job.py
@@ -1264,8 +1264,9 @@ def update_vmware_job(module, job_meta_data, job_details):
 
 def delete_sources(module, job_meta_data, job_details):
     missing_sources = []
-    job_details["environment"] = "Physical"
     try:
+        if module.params.get("environment") == "PhysicalFiles":
+            job_details["environment"] = "Physical"
         for source in module.params.get("protection_sources"):
             job_details["endpoint"] = source["endpoint"]
             source_id = get__prot_source_id__by_endpoint(module, job_details)

--- a/plugins/modules/cohesity_source.py
+++ b/plugins/modules/cohesity_source.py
@@ -238,7 +238,7 @@ EXAMPLES = """
     endpoint: \\\\myfileserver.host.lab\\data
     environment: GenericNas
     nas_protocol: SMB
-    nas_username: administrator
+    nas_username: DOMAIN/administrator or administrator@DOMAIN
     nas_password: password
     state: present
 
@@ -659,10 +659,15 @@ def main():
                 prot_sources["nasMountCredentials"]["nasProtocol"] = "kNfs3"
             elif module.params.get("nas_protocol") == "SMB":
                 prot_sources["nasMountCredentials"]["nasProtocol"] = "kCifs1"
-                if "\\" in ["nas_username"]:
-                    user_details = module.params.get("nas_username").split("\\")
+                nas_username = module.params.get("nas_username")
+                if "/" in nas_username:
+                    user_details = module.params.get("nas_username").split("/")
                     prot_sources["nasMountCredentials"]["username"] = user_details[1]
                     prot_sources["nasMountCredentials"]["domain"] = user_details[0]
+                elif "@" in nas_username:
+                    user_details = nas_username.split("@")
+                    prot_sources["nasMountCredentials"]["domain"] = user_details[1]
+                    prot_sources["nasMountCredentials"]["username"] = user_details[0]
                 else:
                     prot_sources["nasMountCredentials"]["username"] = module.params.get(
                         "nas_username"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-cohesity-management-sdk
+cohesity-management-sdk==1.10.1
 pywinrm
+requests==2.20
+ansible==9.2.0


### PR DESCRIPTION
Issue:
1) Registering SMB source fails if username contains @, format: user@domain 2) If user name is provided in following format: domain\username, source
   is registered but username is precede with slash.

Fix:
1) Add fix to support above formats and tested the same