### PR TITLE
Fix cohesity_agent and v1.4.3 release

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,6 +1,11 @@
 ---
 ancestor: 1.3.0
 releases:
+  1.4.3:
+    release_date: '2026-04-22'
+    changes:
+      bugfixes:
+        - cohesity_agent - Fixed agent detection failing with "Cohesity Agent is partially installed" on systemd hosts where the SysV init script is not created by the installer.
   1.4.2:
     release_date: '2025-01-30'
     changes:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ namespace: cohesity
 name: dataprotect
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.4.2
+version: 1.4.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/module_utils/cohesity_constants.py
+++ b/plugins/module_utils/cohesity_constants.py
@@ -1,3 +1,3 @@
 # Copyright (c) 2024 Cohesity Inc
 
-RELEASE_VERSION = "1.4.2"
+RELEASE_VERSION = "1.4.3"

--- a/plugins/modules/cohesity_agent.py
+++ b/plugins/modules/cohesity_agent.py
@@ -125,6 +125,7 @@ version_added: 1.3.0
 
 import os
 import json
+import pwd
 import time
 import shutil
 
@@ -226,10 +227,29 @@ def check_agent(module, results):
     aix_agent_path = "/usr/local/cohesity/agent/aix_agent.sh"
     def_agent_path = "/etc/init.d/cohesity-agent"
 
-    # Look for default ansible agent path and aix agent path.
+    # On systemd hosts the installer registers a systemd unit and does NOT
+    # create the SysV script at def_agent_path.  The agent binary lives at
+    # ~<service_user>/<service_user>/software/crux/bin/cohesity_linux_agent.sh
+    # Resolve the actual home directory from the OS user database so this
+    # works regardless of where the home directory is located.
+    crux_agent_path = None
+    service_user = module.params.get("service_user") or "cohesityagent"
+    try:
+        home_dir = pwd.getpwnam(service_user).pw_dir
+        crux_agent_path = os.path.join(
+            home_dir, service_user, "software", "crux", "bin",
+            "cohesity_linux_agent.sh"
+        )
+    except KeyError:
+        # Service user does not exist (agent not installed yet).
+        pass
+
+    # Check paths in order: SysV script, crux binary, AIX agent.
     agent_path = (
         def_agent_path
         if os.path.exists(def_agent_path)
+        else crux_agent_path
+        if crux_agent_path and os.path.exists(crux_agent_path)
         else aix_agent_path
         if os.path.exists(aix_agent_path)
         else None

--- a/plugins/modules/cohesity_agent.py
+++ b/plugins/modules/cohesity_agent.py
@@ -233,11 +233,14 @@ def check_agent(module, results):
     # Resolve the actual home directory from the OS user database so this
     # works regardless of where the home directory is located.
     crux_agent_path = None
-    service_user = module.params.get("service_user") or "cohesityagent"
+    service_user = module.params.get("service_user")
     try:
-        home_dir = pwd.getpwnam(service_user).pw_dir
+        if service_user == "root":
+            install_root = "/opt"
+        else:
+            install_root = pwd.getpwnam(service_user).pw_dir
         crux_agent_path = os.path.join(
-            home_dir, service_user, "software", "crux", "bin",
+            install_root, "cohesityagent", "software", "crux", "bin",
             "cohesity_linux_agent.sh"
         )
     except KeyError:


### PR DESCRIPTION
**Bugfixes:**
cohesity_agent - Fixed agent detection failing with "Cohesity Agent is partially installed" on systemd hosts where the SysV init script is not created by the installer.