### PR TITLE
Ansible vulnerability fixes for release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,29 @@
+==================================
+Cohesity.Dataprotect Release Notes
+==================================
+
+.. contents:: Topics
+
+This changelog describes changes after version 1.3.0.
+
+v1.4.3
+======
+
+Bugfixes
+--------
+
+- cohesity_agent - Fixed agent detection failing with "Cohesity Agent is partially installed" on systemd hosts where the SysV init script is not created by the installer.
+
+v1.4.2
+======
+
+Major Changes
+-------------
+
+- Ansible-Core Minimum Version Bumped to 2.16
+
+Bugfixes
+--------
+
+- Fixed LiteralPath Issue During Cohesity Window Agent Installation
+- Fixed collection failure issues for some ansible version

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ To install the requirements, run **pip install -r [requirement.txt](https://gith
 
  - [Getting Started](https://github.com/cohesity/ansible-collection/blob/main/README.md#get-started)
  - [More samples playbooks](https://github.com/cohesity/ansible-collection/blob/main/README.md#examples)
+ - [Changelog](#changelog)
+ - [Support (Red Hat Users)](#support-red-hat-users)
  - [How can you contribute](https://github.com/cohesity/ansible-collection/blob/main/README.md#contribute)
  - [Suggestions and Feedback](https://github.com/cohesity/ansible-collection/blob/main/README.md#suggest)
  - [Disclaimer](#disclaimer)
@@ -52,7 +54,29 @@ To install the requirements, run **pip install -r [requirement.txt](https://gith
 
 * Refer [`playbooks`](https://github.com/cohesity/ansible-collection/tree/main/playbooks) folder to find more examples.
 
+## <a name="changelog"></a> Changelog
+
+See [CHANGELOG.rst](https://github.com/cohesity/ansible-collection/blob/main/CHANGELOG.rst) for a full list of changes by version.
+
+**Recent highlights:**
+
+- **v1.4.3** — Fixed agent detection failing with "Cohesity Agent is partially installed" on systemd hosts where the SysV init script is not created by the installer.
+- **v1.4.2** — Bumped minimum Ansible-Core version to 2.16; fixed `LiteralPath` issue during Windows agent installation and collection failure issues on some Ansible versions.
+
+## Support (Red Hat Users)
+
+This collection is part of **Red Hat Ansible Certified Content** and is entitled to support through the [Ansible Automation Platform (AAP)](https://www.redhat.com/en/technologies/management/ansible).
+
+If you are an AAP subscriber, you can open a support case directly from **Ansible Automation Hub**:
+
+1. Navigate to the collection page on [Ansible Automation Hub](https://console.redhat.com/ansible/automation-hub/repo/published/cohesity/dataprotect/).
+2. Click the **Create issue** button to file a support ticket with Red Hat.
+
+For issues or feature requests outside of an AAP subscription, use the [GitHub issue tracker](https://github.com/cohesity/ansible-collection/issues/new/choose).
+
 ## <a name="contribute"></a> Contribute
+
+* [Refer our contribution guideline](https://github.com/cohesity/ansible-collection/tree/main/CONTRIBUTING.md).
 
 * [Refer our contribution guideline](https://github.com/cohesity/ansible-collection/tree/main/CONTRIBUTING.md).
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,16 +1,17 @@
----
 ancestor: 1.3.0
 releases:
-  1.4.3:
-    release_date: '2026-04-22'
-    changes:
-      bugfixes:
-        - cohesity_agent - Fixed agent detection failing with "Cohesity Agent is partially installed" on systemd hosts where the SysV init script is not created by the installer.
   1.4.2:
-    release_date: '2025-01-30'
     changes:
-      major_changes:
-        - Ansible-Core Minimum Version Bumped to 2.16
       bugfixes:
-        - Fixed collection failure issues for some ansible version
-        - Fixed LiteralPath Issue During Cohesity Window Agent Installation
+      - Fixed LiteralPath Issue During Cohesity Window Agent Installation
+      - Fixed collection failure issues for some ansible version
+      major_changes:
+      - Ansible-Core Minimum Version Bumped to 2.16
+    release_date: '2025-01-30'
+  1.4.3:
+    changes:
+      bugfixes:
+      - cohesity_agent - Fixed agent detection failing with "Cohesity Agent is partially
+        installed" on systemd hosts where the SysV init script is not created by the
+        installer.
+    release_date: '2026-04-22'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cohesity-management-sdk==1.10.1
 pywinrm
-requests==2.31.0
+requests>=2.31.0
 ansible-core==2.16.3


### PR DESCRIPTION
## Ansible vulnerability fixes for release
Followings issues are addressed in this release 
  

>  change `requests>=2.31.0` in requirements.txt
>  regenerate CHANGELOG.rst and Add in Readme
>  add the support section in README
